### PR TITLE
Add localhost to origins and fix requirements

### DIFF
--- a/backend/api/api/settings.py
+++ b/backend/api/api/settings.py
@@ -31,7 +31,8 @@ SECRET_KEY = os.getenv("SECRET_KEY")
 DEBUG = True
 
 ALLOWED_HOSTS = [
-    "taconnect-local.lbl.gov"
+    "taconnect-local.lbl.gov",
+    "127.0.0.1"
 ]
 
 

--- a/backend/api/requirements.txt
+++ b/backend/api/requirements.txt
@@ -1,5 +1,5 @@
 asgiref==3.8.1
-backports.zoneinfo==0.2.1
+backports.zoneinfo==0.2.1;python_version<"3.9"
 colorama==0.4.6
 Django==5.1.6
 django-cors-headers==4.7.0


### PR DESCRIPTION
Allow backend app to run on localhost and fix the `backports.zoneinfo` requirement so that it works with newer python versions.