### PR TITLE
Add customer panel with data from detail endpoint

### DIFF
--- a/frontend/src/components/InfoPanel.tsx
+++ b/frontend/src/components/InfoPanel.tsx
@@ -1,0 +1,36 @@
+import { Paper, Typography } from '@mui/material';
+
+interface InfoPanelProps {
+  header: React.ReactNode;
+  children: React.ReactNode;
+}
+
+export const InfoPanel: React.FC<InfoPanelProps> = ({ header, children }) => {
+  return (
+    <Paper
+      sx={{
+        height: 'stretch',
+        width: 'stretch',
+        borderWidth: 10,
+        borderStyle: 'solid',
+        borderColor: 'primary.main',
+        borderRadius: 0,
+        borderTopLeftRadius: 5,
+        borderTopRightRadius: 5,
+      }}
+    >
+      <Typography
+        component="h3"
+        sx={{
+          textAlign: 'center',
+          backgroundColor: 'primary.main',
+          color: 'primary.contrastText',
+          paddingBottom: 1,
+        }}
+      >
+        {header}
+      </Typography>
+      {children}
+    </Paper>
+  );
+};

--- a/frontend/src/components/InfoPanel.tsx
+++ b/frontend/src/components/InfoPanel.tsx
@@ -5,6 +5,10 @@ interface InfoPanelProps {
   children: React.ReactNode;
 }
 
+/**
+ * Consistently styled panel for informational content.
+ * The header can be plain text or a more complex React node.
+ */
 export const InfoPanel: React.FC<InfoPanelProps> = ({ header, children }) => {
   return (
     <Paper

--- a/frontend/src/features/requests/RequestAttachments.tsx
+++ b/frontend/src/features/requests/RequestAttachments.tsx
@@ -1,5 +1,6 @@
 import {
   Box,
+  Paper,
   Table,
   TableBody,
   TableCell,
@@ -8,15 +9,36 @@ import {
   Typography,
 } from '@mui/material';
 import { TACustomer } from '../../api/dashboard/types';
-import { InfoPanel } from '../../components/InfoPanel';
 
 interface RequestInfoTableProps {
   customer?: TACustomer;
 }
 
-export const RequestCustomerPanel: React.FC<RequestInfoTableProps> = ({ customer }) => {
+export const RequestAttachments: React.FC<RequestInfoTableProps> = ({ customer }) => {
   return (
-    <InfoPanel header="Customer Information">
+    <Paper
+      sx={{
+        height: 'stretch',
+        width: 'stretch',
+        borderWidth: 10,
+        borderStyle: 'solid',
+        borderColor: 'primary.main',
+        borderRadius: 0,
+        borderTopLeftRadius: 5,
+        borderTopRightRadius: 5,
+      }}
+    >
+      <Typography
+        component="h3"
+        sx={{
+          textAlign: 'center',
+          backgroundColor: 'primary.main',
+          color: 'primary.contrastText',
+          paddingBottom: 1,
+        }}
+      >
+        Customer Information
+      </Typography>
       {!customer && (
         <Box>
           <Typography>No customer data to show.</Typography>
@@ -61,6 +83,6 @@ export const RequestCustomerPanel: React.FC<RequestInfoTableProps> = ({ customer
           </Table>
         </TableContainer>
       )}
-    </InfoPanel>
+    </Paper>
   );
 };

--- a/frontend/src/features/requests/RequestCustomerPanel.tsx
+++ b/frontend/src/features/requests/RequestCustomerPanel.tsx
@@ -1,0 +1,88 @@
+import {
+  Box,
+  Paper,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableRow,
+  Typography,
+} from '@mui/material';
+import { TACustomer } from '../../api/dashboard/types';
+
+interface RequestInfoTableProps {
+  customer?: TACustomer;
+}
+
+export const RequestCustomerPanel: React.FC<RequestInfoTableProps> = ({ customer }) => {
+  return (
+    <Paper
+      sx={{
+        height: 'stretch',
+        width: 'stretch',
+        borderWidth: 10,
+        borderStyle: 'solid',
+        borderColor: 'primary.main',
+        borderRadius: 0,
+        borderTopLeftRadius: 5,
+        borderTopRightRadius: 5,
+      }}
+    >
+      <Typography
+        component="h3"
+        sx={{
+          textAlign: 'center',
+          backgroundColor: 'primary.main',
+          color: 'primary.contrastText',
+          paddingBottom: 1,
+        }}
+      >
+        Customer Information
+      </Typography>
+      {!customer && (
+        <Box>
+          <Typography>No customer data to show.</Typography>
+        </Box>
+      )}
+      {customer && (
+        <TableContainer>
+          <Table size="small">
+            <TableBody>
+              <TableRow>
+                <TableCell>Relationship</TableCell>
+                {/* TODO: Implement relationship in the API */}
+                <TableCell>Unknown</TableCell>
+              </TableRow>
+              <TableRow>
+                <TableCell>Name</TableCell>
+                <TableCell>{customer.name}</TableCell>
+              </TableRow>
+              <TableRow>
+                <TableCell>Email</TableCell>
+                <TableCell>{customer.email}</TableCell>
+              </TableRow>
+              <TableRow>
+                <TableCell>Phone</TableCell>
+                <TableCell>{customer.phone}</TableCell>
+              </TableRow>
+              <TableRow>
+                <TableCell>Job Title</TableCell>
+                <TableCell>{customer.title}</TableCell>
+              </TableRow>
+              <TableRow>
+                <TableCell>Organization</TableCell>
+                {/* TODO: Implement nested organization data in the API */}
+                <TableCell>{customer.org}</TableCell>
+              </TableRow>
+              <TableRow>
+                <TableCell>State</TableCell>
+                {/* TODO: Return state name instead of ID in the API */}
+                <TableCell>{customer.state}</TableCell>
+              </TableRow>
+            </TableBody>
+          </Table>
+        </TableContainer>
+      )}
+    </Paper>
+  );
+};

--- a/frontend/src/features/requests/RequestInfoPanel.tsx
+++ b/frontend/src/features/requests/RequestInfoPanel.tsx
@@ -4,12 +4,12 @@ import {
   TableRow,
   TableBody,
   TableCell,
-  Paper,
   Typography,
   Stack,
 } from '@mui/material';
 import { TARequestDetail } from '../../api/dashboard/types';
 import { capitalize, formatDate } from '../../utils/utils';
+import { InfoPanel } from '../../components/InfoPanel';
 
 interface RequestInfoPanelProps {
   request?: TARequestDetail;
@@ -17,29 +17,7 @@ interface RequestInfoPanelProps {
 
 export const RequestInfoPanel: React.FC<RequestInfoPanelProps> = ({ request }) => {
   return (
-    <Paper
-      sx={{
-        height: 'stretch',
-        width: 'stretch',
-        borderWidth: 10,
-        borderStyle: 'solid',
-        borderColor: 'primary.main',
-        borderRadius: 0,
-        borderTopLeftRadius: 5,
-        borderTopRightRadius: 5,
-      }}
-    >
-      <Typography
-        component="h3"
-        sx={{
-          textAlign: 'center',
-          backgroundColor: 'primary.main',
-          color: 'primary.contrastText',
-          paddingBottom: 1,
-        }}
-      >
-        Request Information
-      </Typography>
+    <InfoPanel header="Request Information">
       <TableContainer>
         <Table size="small">
           <TableBody>
@@ -107,6 +85,6 @@ export const RequestInfoPanel: React.FC<RequestInfoPanelProps> = ({ request }) =
           {request?.description || 'No description for this request.'}
         </Typography>
       </Stack>
-    </Paper>
+    </InfoPanel>
   );
 };

--- a/frontend/src/features/requests/RequestInfoPanel.tsx
+++ b/frontend/src/features/requests/RequestInfoPanel.tsx
@@ -11,11 +11,11 @@ import {
 import { TARequestDetail } from '../../api/dashboard/types';
 import { capitalize, formatDate } from '../../utils/utils';
 
-interface RequestInfoTableProps {
+interface RequestInfoPanelProps {
   request?: TARequestDetail;
 }
 
-export const RequestInfoTable: React.FC<RequestInfoTableProps> = ({ request }) => {
+export const RequestInfoPanel: React.FC<RequestInfoPanelProps> = ({ request }) => {
   return (
     <Paper
       sx={{

--- a/frontend/src/routes/_private/dashboard/requests/$requestId.tsx
+++ b/frontend/src/routes/_private/dashboard/requests/$requestId.tsx
@@ -6,6 +6,8 @@ import {
   Menu,
   MenuItem,
   Stack,
+  Tab,
+  Tabs,
   Typography,
 } from '@mui/material';
 import ArrowDropDownIcon from '@mui/icons-material/ArrowDropDown';
@@ -25,6 +27,8 @@ import { useState } from 'react';
 import { useRequestsContext } from '../../../../features/requests/RequestsContext';
 import { useIdentityContext } from '../../../../features/identity/IdentityContext';
 import { RequestCustomerPanel } from '../../../../features/requests/RequestCustomerPanel';
+import { InfoPanel } from '../../../../components/InfoPanel';
+import { TabPanel } from '../../../../components/TabPanel';
 
 export const Route = createFileRoute('/_private/dashboard/requests/$requestId')({
   loader: async ({ context, params }) => {
@@ -52,6 +56,7 @@ function SelectedRequest() {
   const previousIndex = currentIndex > 0 ? currentIndex - 1 : null;
   const [actionsAnchorEl, setActionsAnchorEl] = useState<null | HTMLElement>(null);
   const actionsMenuOpen = Boolean(actionsAnchorEl);
+  const [tabValue, setTabValue] = useState<string | number>('attachments');
 
   const handleClickActionsMenu = (event: React.MouseEvent<HTMLButtonElement>) => {
     setActionsAnchorEl(event.currentTarget);
@@ -60,6 +65,11 @@ function SelectedRequest() {
   const handleCloseActionsMenu = () => {
     setActionsAnchorEl(null);
   };
+
+  const handleChangeTab = (_event: React.SyntheticEvent, newValue: string | number) => {
+    setTabValue(newValue);
+  };
+
   return (
     <Stack>
       <Stack direction="row">
@@ -173,7 +183,34 @@ function SelectedRequest() {
         <Grid size={6}>
           <Stack>
             <RequestCustomerPanel customer={selectedRequest?.customers[0]} />
-            <Button sx={{ height: 'stretch', width: 'stretch', bgcolor: 'blue' }}></Button>
+            <InfoPanel
+              header={
+                <Tabs
+                  onChange={handleChangeTab}
+                  value={tabValue}
+                  textColor="inherit"
+                  indicatorColor="primary"
+                >
+                  <Tab
+                    label="Attachments"
+                    value="attachments"
+                    onClick={(event) => handleChangeTab(event, 'attachments')}
+                  />
+                  <Tab
+                    label="Audit History"
+                    value="audit-history"
+                    onClick={(event) => handleChangeTab(event, 'audit-history')}
+                  />
+                </Tabs>
+              }
+            >
+              <TabPanel value={tabValue} index="attachments">
+                Attachments
+              </TabPanel>
+              <TabPanel value={tabValue} index="audit-history">
+                Audit history
+              </TabPanel>
+            </InfoPanel>
           </Stack>
         </Grid>
       </Grid>

--- a/frontend/src/routes/_private/dashboard/requests/$requestId.tsx
+++ b/frontend/src/routes/_private/dashboard/requests/$requestId.tsx
@@ -18,12 +18,13 @@ import EditIcon from '@mui/icons-material/Edit';
 import WestIcon from '@mui/icons-material/West';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { createFileRoute } from '@tanstack/react-router';
-import { RequestInfoTable } from '../../../../features/requests/RequestsInfoTable';
+import { RequestInfoPanel } from '../../../../features/requests/RequestInfoPanel';
 import { requestDetailQueryOptions } from '../../../../utils/queryOptions';
 import { AppLink } from '../../../../components/AppLink';
 import { useState } from 'react';
 import { useRequestsContext } from '../../../../features/requests/RequestsContext';
 import { useIdentityContext } from '../../../../features/identity/IdentityContext';
+import { RequestCustomerPanel } from '../../../../features/requests/RequestCustomerPanel';
 
 export const Route = createFileRoute('/_private/dashboard/requests/$requestId')({
   loader: async ({ context, params }) => {
@@ -165,13 +166,13 @@ function SelectedRequest() {
           Assign
         </Button>
       </Stack>
-      <Grid container>
+      <Grid container spacing={2}>
         <Grid size={6} sx={{ minHeight: 550 }}>
-          <RequestInfoTable request={selectedRequest!} />
+          <RequestInfoPanel request={selectedRequest!} />
         </Grid>
         <Grid size={6}>
           <Stack>
-            <Button sx={{ height: 'stretch', width: 'stretch', bgcolor: 'blue' }}></Button>
+            <RequestCustomerPanel customer={selectedRequest?.customers[0]} />
             <Button sx={{ height: 'stretch', width: 'stretch', bgcolor: 'blue' }}></Button>
           </Stack>
         </Grid>


### PR DESCRIPTION
Add the customer information panel with data from the detail endpoint. Currently this is showing the first customer in the customer list but this could change later when only the primary customer is returned.

Includes the addition of `InfoPanel` which is a styled panel component used throughout the request detail components.