### PR TITLE
Feature/cancel endpoint

### DIFF
--- a/backend/api/core/constants.py
+++ b/backend/api/core/constants.py
@@ -11,3 +11,15 @@ class ROLE(str, Enum):
     PROGRAM_LEAD = "Program Lead"
     LAB_LEAD = "Lab Lead"
     EXPERT = "Expert"
+
+class REQUEST_STATUS(str, Enum):
+    SCOPING = "Scoping"
+    ASSIGNED_TO_PROGRAM = "Assigned to Program"
+    REJECTED_BY_PROGRAM = "Rejected by Program"
+    ASSIGNED_TO_LAB = "Assigned to Lab"
+    REASSIGNMENT_REQUESTED = "Reassignment Requested"
+    ASSIGNED_TO_EXPERT = "Assigned to Expert"
+    PROVIDING_TA = "Providing TA"
+    CLOSE_OUT = "Close out"
+    COMPLETED = "Completed"
+    UNABLE_TO_ADDRESS = "Unable to address"

--- a/backend/api/core/urls.py
+++ b/backend/api/core/urls.py
@@ -7,6 +7,7 @@ urlpatterns = [
     path('requests/', RequestListView.as_view(), name="request-list"),
     path('requests/<int:id>', RequestDetailView.as_view(), name="request-detail"),
     path('requests/<int:id>/mark-complete/', RequestMarkCompleteView.as_view(), name="mark-complete"),
+    path('requests/<int:id>/cancel/', RequestCancelView.as_view(), name="mark-complete"),
     path('requests/assign/', AssignmentView.as_view(), name="assignment"),
 
     path('identities/', IdentityListView.as_view(), name="identities-list"),

--- a/backend/api/core/urls.py
+++ b/backend/api/core/urls.py
@@ -6,6 +6,7 @@ urlpatterns = [
     
     path('requests/', RequestListView.as_view(), name="request-list"),
     path('requests/<int:id>', RequestDetailView.as_view(), name="request-detail"),
+    path('requests/<int:id>/mark-complete/', RequestMarkCompleteView.as_view(), name="mark-complete"),
     path('requests/assign/', AssignmentView.as_view(), name="assignment"),
 
     path('identities/', IdentityListView.as_view(), name="identities-list"),

--- a/backend/api/core/views/__init__.py
+++ b/backend/api/core/views/__init__.py
@@ -1,4 +1,4 @@
-from .request import RequestListView, RequestDetailView
+from .request import RequestListView, RequestDetailView, RequestMarkCompleteView
 from .depth import DepthListView, DepthRetrieveView
 from .state import StateListView, StateRetrieveView
 from .organization_type import OrganizationTypeListView, OrganizationTypeRetrieveView
@@ -20,6 +20,7 @@ __all__ = [
     "IdentityListView",
     "RequestListView",
     "RequestDetailView",
+    "RequestMarkCompleteView",
     "DepthListView",
     "DepthRetrieveView",
     "StateListView",

--- a/backend/api/core/views/__init__.py
+++ b/backend/api/core/views/__init__.py
@@ -1,4 +1,4 @@
-from .request import RequestListView, RequestDetailView, RequestMarkCompleteView
+from .request import RequestListView, RequestDetailView, RequestMarkCompleteView, RequestCancelView
 from .depth import DepthListView, DepthRetrieveView
 from .state import StateListView, StateRetrieveView
 from .organization_type import OrganizationTypeListView, OrganizationTypeRetrieveView
@@ -21,6 +21,7 @@ __all__ = [
     "RequestListView",
     "RequestDetailView",
     "RequestMarkCompleteView",
+    "RequestCancelView",
     "DepthListView",
     "DepthRetrieveView",
     "StateListView",

--- a/backend/api/core/views/request.py
+++ b/backend/api/core/views/request.py
@@ -415,6 +415,7 @@ class RequestCancelView(BaseUserAwareRequest):
             with transaction.atomic():
                 found_request.status = RequestStatus.objects.get(name=REQUEST_STATUS.UNABLE_TO_ADDRESS)
                 found_request.owner = None
+                found_request.expert = None
 
                 found_request.receipt.program = None
                 found_request.receipt.lab = None

--- a/backend/api/core/views/request.py
+++ b/backend/api/core/views/request.py
@@ -349,3 +349,7 @@ class RequestListView(BaseUserAwareRequest):
             response_data[tag] = requests_data
 
         return Response(data=response_data, status=status.HTTP_200_OK)
+
+class RequestCancelView(BaseUserAwareRequest):
+    def get(self, request, id=None):
+        return Response(status=status.HTTP_501_NOT_IMPLEMENTED)

--- a/backend/api/core/views/request.py
+++ b/backend/api/core/views/request.py
@@ -397,4 +397,33 @@ class RequestMarkCompleteView(BaseUserAwareRequest):
 
 class RequestCancelView(BaseUserAwareRequest):
     def get(self, request, id=None):
-        return Response(status=status.HTTP_501_NOT_IMPLEMENTED)
+        if id is None:
+            return Response(data={"message": "Please provide a Request ID"}, status=status.HTTP_400_BAD_REQUEST)
+
+        if not (IsCoordinator().has_permission(request) or IsAdmin().has_permission(request)):
+            return Response(data={"message": "Insufficient privillege to mark request as complete"}, status=status.HTTP_401_UNAUTHORIZED)
+
+        queryset = self.get_actionable()
+
+        found_request = None
+        try:
+            found_request = queryset.get(pk=id)        
+        except:
+            return Response(data={"message": "Request with given ID does not exist"}, status=status.HTTP_404_NOT_FOUND)
+
+        try:
+            with transaction.atomic():
+                found_request.status = RequestStatus.objects.get(name=REQUEST_STATUS.UNABLE_TO_ADDRESS)
+                found_request.owner = None
+
+                found_request.receipt.program = None
+                found_request.receipt.lab = None
+                found_request.receipt.expert = None
+
+                found_request.receipt.save()
+                found_request.save()
+
+        except Exception as e:
+            return Response(data={"message": f"{e}"}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+
+        return Response(status=status.HTTP_200_OK)


### PR DESCRIPTION
Implements the Cancel action.

Endpoint:

- POST request to BACKEND/requests/$(request ID)/cancel.
Only a Coordinator or an Admin may mark a request as complete.

Side Effects:

- request's Status is set to "Unable to address"
- request's Owner is set to null -> a canceled request no longer needs an owner (owned by "system")
 -request's Expert is set to null -> a canceled request is no longer being worked on by an Expert
- clearing entirety of request's receipt

The clearing of Owner field will need adaptation from the frontend as it seems right now Owner is always expected to be present. Or we can work on an alternative.

For example we are making assumption on the existence of owners by accessing properties:

<img width="567" height="63" alt="image" src="https://github.com/user-attachments/assets/e418b3ad-17ad-45eb-8fbd-0882395e2f08" />

<img width="687" height="253" alt="image" src="https://github.com/user-attachments/assets/80d0cf91-2fbd-4c7e-af26-0eeecf70fa24" />