### PR TITLE
Bugfix/rework experts endpoint

### DIFF
--- a/backend/api/core/urls.py
+++ b/backend/api/core/urls.py
@@ -16,7 +16,7 @@ urlpatterns = [
     path('statuses/', StatusListView.as_view(), name="statuses-list"),
 
     path('owners/', OwnerListView.as_view(), name="owners-list"),
-    path('experts/<str:lab_name>', ExpertsListView.as_view(), name="experts-list"),
+    path('experts/', ExpertsListView.as_view(), name="experts-list"),
 
     
     path('depths/', DepthListView.as_view(), name="depth-list"),

--- a/backend/api/core/views/expert.py
+++ b/backend/api/core/views/expert.py
@@ -48,7 +48,7 @@ class ExpertsListView(views.APIView):
             data["id"] = assignment.user.pk
             data["name"] = assignment.user.name
             data["email"] = assignment.user.email
-            data["lab"] = assignment.instance
+            data["lab"] = LabSerializer(assignment.instance).data
 
             expertise_list = Expertise.objects.filter(user=assignment.user.pk)
             expertise = dict()


### PR DESCRIPTION
Experts endpoint no longer requires a lab name, instead provides that information in the response.

Expects a context aware GET request to BACKEND/experts/

New response shape:

```
{
    {
        "id": (expert/user id),
        "name": (expert/user name),
        "email": (expert/user email),
        "lab": { (...lab info) }
        "expertise": [
            {
                "topic": {"id": (topic id), "name": (topic name), "description": (topic description)},
                "depth": {"id": (depth id), "name": (depth name), "description": (depth description)}
            },
            ...
        ]
    },
    ...
}
```