### PR TITLE
Added more expert info to request detail

### DIFF
--- a/backend/api/core/views/request.py
+++ b/backend/api/core/views/request.py
@@ -217,6 +217,9 @@ class RequestDetailView(BaseUserAwareRequest):
         response_data = response_data | request_serializer.data 
         response_data["customers"] = customer_serializer.data
         response_data["owner"] = OwnerSerializer().format_owner(found_request.owner)
+        
+        if found_request.expert is not None:
+            response_data["expert"] = UserLeanSerializer(found_request.expert).data
 
         return Response(data=response_data, status=status.HTTP_200_OK)
 

--- a/frontend/src/api/dashboard/types.ts
+++ b/frontend/src/api/dashboard/types.ts
@@ -85,7 +85,11 @@ export interface TARequestDetail {
   description: string;
   date_created: string;
   customers: TACustomer[];
-  expert: string | null;
+  expert: {
+    id: number;
+    email: string;
+    phone: string;
+  } | null;
   owner?: TAOwner;
   proj_start_date: string | null;
   proj_completion_date: string | null;

--- a/frontend/src/features/requests/RequestInfoPanel.tsx
+++ b/frontend/src/features/requests/RequestInfoPanel.tsx
@@ -223,7 +223,7 @@ export const RequestInfoPanel: React.FC<RequestInfoPanelProps> = ({ request }) =
                 </TableRow>
                 <TableRow>
                   <TableCell>Assigned Expert</TableCell>
-                  <TableCell>{request.expert ? request.expert : 'None'}</TableCell>
+                  <TableCell>{request.expert ? request.expert.email : 'None'}</TableCell>
                 </TableRow>
                 <TableRow>
                   <TableCell>Status</TableCell>


### PR DESCRIPTION
Instead of returning just an email in place for the expert field, now we return an expert object with additional information:

``` 
// Request detail response object
...
expert : {
    id: (number),
    email: (string),
    phone: (string),
}
...
```