### PR TITLE
Add topics and topics editing to the UI

### DIFF
--- a/frontend/src/api/dashboard/types.ts
+++ b/frontend/src/api/dashboard/types.ts
@@ -70,6 +70,7 @@ export interface TARequest {
   proj_start_date: string | null;
   proj_completion_date: string | null;
   actual_completion_date: string | null;
+  topics: TATopic[] | TATopic['name'][];
 }
 
 export interface TAStatus {
@@ -94,7 +95,7 @@ export interface TARequestDetail {
   proj_start_date: string | null;
   proj_completion_date: string | null;
   actual_completion_date: string | null;
-  topics: string[];
+  topics: TATopic[];
 }
 
 export interface TAIdentity {

--- a/frontend/src/features/requests/RequestCustomerPanel.tsx
+++ b/frontend/src/features/requests/RequestCustomerPanel.tsx
@@ -24,7 +24,7 @@ export const RequestCustomerPanel: React.FC<RequestInfoTableProps> = ({ customer
       )}
       {customer && (
         <TableContainer>
-          <Table size="small">
+          <Table size="small" sx={{ '& .MuiTableCell-root:first-child': { width: '205px' } }}>
             <TableBody>
               <TableRow>
                 <TableCell>Relationship</TableCell>

--- a/frontend/src/features/requests/RequestInfoPanel.tsx
+++ b/frontend/src/features/requests/RequestInfoPanel.tsx
@@ -211,7 +211,7 @@ export const RequestInfoPanel: React.FC<RequestInfoPanelProps> = ({ request }) =
       {request && (
         <>
           <TableContainer>
-            <Table size="small">
+            <Table size="small" sx={{ '& .MuiTableCell-root:first-child': { width: '205px' } }}>
               <TableBody>
                 <TableRow>
                   <TableCell>ID</TableCell>

--- a/frontend/src/features/requests/RequestInfoPanel.tsx
+++ b/frontend/src/features/requests/RequestInfoPanel.tsx
@@ -4,8 +4,10 @@ import ClearIcon from '@mui/icons-material/Clear';
 import EditIcon from '@mui/icons-material/Edit';
 import ErrorIcon from '@mui/icons-material/Error';
 import {
+  Autocomplete,
   Chip,
   CircularProgress,
+  Grid,
   IconButton,
   MenuItem,
   Select,
@@ -23,13 +25,14 @@ import { DatePicker } from '@mui/x-date-pickers';
 import { PickerValue } from '@mui/x-date-pickers/internals';
 import dayjs, { Dayjs } from 'dayjs';
 import { useCallback, useEffect, useState } from 'react';
-import { TARequest, TARequestDetail } from '../../api/dashboard/types';
+import { TARequest, TARequestDetail, TATopic } from '../../api/dashboard/types';
 import { InfoPanel } from '../../components/InfoPanel';
-import { useRequestMutation } from '../../utils/queryOptions';
+import { topicsQueryOptions, useRequestMutation } from '../../utils/queryOptions';
 import { capitalize, formatDatetime } from '../../utils/utils';
 import { useIdentityContext } from '../identity/IdentityContext';
 import { useToastContext } from '../toasts/ToastContext';
 import { ToastMessage } from '../toasts/ToastMessage';
+import { useSuspenseQuery } from '@tanstack/react-query';
 
 interface RequestInfoPanelProps {
   request?: TARequestDetail;
@@ -38,6 +41,7 @@ interface RequestInfoPanelProps {
 export const RequestInfoPanel: React.FC<RequestInfoPanelProps> = ({ request }) => {
   const { identity } = useIdentityContext();
   const updateRequestMutation = useRequestMutation(request?.id.toString() || '', identity);
+  const { data: allTopics } = useSuspenseQuery(topicsQueryOptions());
   const [editing, setEditing] = useState(false);
   const { setShowToast, setToastMessage } = useToastContext();
   const [depth, setDepth] = useState<TARequestDetail['depth']>();
@@ -45,7 +49,7 @@ export const RequestInfoPanel: React.FC<RequestInfoPanelProps> = ({ request }) =
   const [projectedCompletionDate, setProjectedCompletionDate] = useState<Dayjs>();
   const [actualCompletionDate, setActualCompletionDate] = useState<Dayjs>();
   const [description, setDescription] = useState('');
-  // const [topics, setTopics] = useState<TARequestDetail['topics']>([]);
+  const [topics, setTopics] = useState<TARequestDetail['topics']>([]);
 
   /**
    * Reset form values based on request data.
@@ -64,7 +68,7 @@ export const RequestInfoPanel: React.FC<RequestInfoPanelProps> = ({ request }) =
         request.actual_completion_date ? dayjs(request.actual_completion_date) : undefined
       );
 
-      // setTopics(request.topics || []);
+      setTopics(request.topics || []);
       setDescription(request.description || '');
     }
   }, [request]);
@@ -113,10 +117,14 @@ export const RequestInfoPanel: React.FC<RequestInfoPanelProps> = ({ request }) =
     ) {
       mutationData.actual_completion_date = actualCompletionDate.format('YYYY-MM-DD');
     }
+    // Always send topics, even if they are unchanged
+    // We could add a special function to check if topics have changed
+    mutationData.topics = topics.map((topic) => topic.name);
     if (Object.keys(mutationData).length === 0) {
       setEditing(false);
       return;
     }
+    console.log('Submitting request update:', mutationData);
     updateRequestMutation.mutate(mutationData);
   };
 
@@ -144,6 +152,10 @@ export const RequestInfoPanel: React.FC<RequestInfoPanelProps> = ({ request }) =
 
   const handleActualCompletionDateChange = (value: PickerValue) => {
     setActualCompletionDate(value as Dayjs);
+  };
+
+  const handleTopicsChange = (_event: React.SyntheticEvent, newValue: TATopic[]) => {
+    setTopics(newValue);
   };
 
   useEffect(() => {
@@ -320,8 +332,39 @@ export const RequestInfoPanel: React.FC<RequestInfoPanelProps> = ({ request }) =
                 </TableRow>
                 <TableRow>
                   <TableCell>Topics</TableCell>
-                  {/* TODO: Implement topics in the API and display */}
-                  <TableCell>Unknown</TableCell>
+                  <TableCell>
+                    {!editing && (
+                      <Grid container spacing={1}>
+                        {request.topics && request.topics.length > 0 ? (
+                          request.topics.map((topic) => (
+                            <Grid key={topic.id} size="auto">
+                              <Chip
+                                key={topic.name}
+                                label={topic.name}
+                                color="default"
+                                size="small"
+                              />
+                            </Grid>
+                          ))
+                        ) : (
+                          <span>None</span>
+                        )}
+                      </Grid>
+                    )}
+                    {editing && (
+                      <Autocomplete
+                        multiple
+                        options={allTopics || []}
+                        getOptionLabel={(option) => option.name}
+                        value={topics || []}
+                        onChange={handleTopicsChange}
+                        renderInput={(params) => (
+                          <TextField {...params} variant="outlined" label="Topics" />
+                        )}
+                        disableCloseOnSelect
+                      />
+                    )}
+                  </TableCell>
                 </TableRow>
               </TableBody>
             </Table>

--- a/frontend/src/features/requests/RequestInfoPanel.tsx
+++ b/frontend/src/features/requests/RequestInfoPanel.tsx
@@ -194,12 +194,12 @@ export const RequestInfoPanel: React.FC<RequestInfoPanelProps> = ({ request }) =
           {editing && (
             <Stack direction="row">
               {!updateRequestMutation.isPending && (
-                <IconButton color="info" onClick={handleEditSubmit}>
+                <IconButton onClick={handleEditSubmit}>
                   <CheckIcon />
                 </IconButton>
               )}
               {updateRequestMutation.isPending && <CircularProgress />}
-              <IconButton color="info" onClick={handleEditCancel}>
+              <IconButton onClick={handleEditCancel}>
                 <ClearIcon />
               </IconButton>
             </Stack>

--- a/frontend/src/routes/_private/dashboard/requests/$requestId.tsx
+++ b/frontend/src/routes/_private/dashboard/requests/$requestId.tsx
@@ -17,6 +17,7 @@ import {
   expertsQueryOptions,
   ownersQueryOptions,
   requestDetailQueryOptions,
+  topicsQueryOptions,
 } from '../../../../utils/queryOptions';
 
 export const Route = createFileRoute('/_private/dashboard/requests/$requestId')({
@@ -25,6 +26,7 @@ export const Route = createFileRoute('/_private/dashboard/requests/$requestId')(
       requestDetailQueryOptions(params.requestId, context.identity)
     );
     await context.queryClient.ensureQueryData(ownersQueryOptions(context.identity));
+    await context.queryClient.ensureQueryData(topicsQueryOptions());
     if (
       context.detailedIdentity?.role.name === 'Lab Lead' ||
       context.detailedIdentity?.role.name === 'Admin'

--- a/frontend/src/utils/queryOptions.ts
+++ b/frontend/src/utils/queryOptions.ts
@@ -20,6 +20,7 @@ import {
   TARequestDetail,
   TARequestsResponse,
   TAStatus,
+  TATopic,
 } from '../api/dashboard/types';
 import { queryClient } from '../App';
 import { Identity } from '../features/identity/IdentityContext';
@@ -112,6 +113,15 @@ export const expertsQueryOptions = (identity?: Identity) =>
       } else {
         return [];
       }
+    },
+  });
+
+export const topicsQueryOptions = () =>
+  queryOptions({
+    staleTime: 120_000, // stale after 2 minutes
+    queryKey: ['topics'],
+    queryFn: () => {
+      return fetchData<TATopic[]>(`${apiUrl}/topics/`);
     },
   });
 


### PR DESCRIPTION
Display topics from the API in the request info table. Only displays the topic `name`. Topics can also be edited using an [autocomplete multi select component](https://mui.com/material-ui/react-autocomplete/#multiple-values). The options for the component are populated from the `/topics` endpoint. Before being sent to the PATCH endpoint for editing, the topics array is transformed to a simple array of name strings.