### PR TITLE
Feature/edit customer info

### DIFF
--- a/backend/api/core/models/transmission_planning_region.py
+++ b/backend/api/core/models/transmission_planning_region.py
@@ -1,7 +1,7 @@
 from django.db import models
 
 class TransmissionPlanningRegion(models.Model):
-    name = models.CharField(max_length=256)
+    name = models.CharField(max_length=256, unique=True)
     
     def __str__(self):
         return self.name

--- a/backend/api/core/serializers/__init__.py
+++ b/backend/api/core/serializers/__init__.py
@@ -4,7 +4,7 @@ from .transmission_planning_region import TransmissionPlanningRegionSerializer
 from .organization_type import OrganizationTypeSerializer
 from .organization import OrganizationSerializer
 from .customer_type import CustomerTypeSerializer
-from .customer import CustomerSerializer
+from .customer import CustomerSerializer, CustomerEditSerializer
 from .depth import DepthSerializer
 from .lab import LabSerializer
 from .program import ProgramSerializer
@@ -29,6 +29,7 @@ __all__ = [
     "OwnerSerializer",
     "RequestSerializer",
     "CustomerSerializer",
+    "CustomerEditSerializer",
     "RequestListSerializer",
     "RequestDetailSerializer",
     "DepthSerializer",

--- a/backend/api/core/serializers/customer.py
+++ b/backend/api/core/serializers/customer.py
@@ -1,12 +1,25 @@
 from rest_framework import serializers
 
-from core.models import Customer
+from core.models import *
 from core.serializers import * 
 
 class CustomerSerializer(serializers.ModelSerializer):
     org = OrganizationSerializer()
     state = StateSerializer()
     tpr = TransmissionPlanningRegionSerializer() 
+
+    class Meta:
+        model = Customer
+        fields = "__all__"
+
+class CustomerEditSerializer(serializers.ModelSerializer):
+    org = serializers.PrimaryKeyRelatedField(queryset=Organization.objects.all(), required=False)
+    state = serializers.PrimaryKeyRelatedField(queryset=State.objects.all(), required=False)
+    tpr = serializers.PrimaryKeyRelatedField(queryset=TransmissionPlanningRegion.objects.all(), required=False)
+    email = serializers.EmailField(max_length=256, required=False, allow_null=True)
+    name = serializers.CharField(max_length=256, required=False, allow_null=True)
+    phone = serializers.CharField(max_length=64, required=False, allow_null=True)
+    title = serializers.CharField(max_length=256, required=False, allow_null=True)
 
     class Meta:
         model = Customer

--- a/backend/api/core/urls.py
+++ b/backend/api/core/urls.py
@@ -27,17 +27,17 @@ urlpatterns = [
     path('states/', StateListView.as_view(), name="state-list"),
     path('states/<int:pk>', StateRetrieveView.as_view(), name="state-retrieve"),
     
-    path('organizations/', OrganizationListCreateView.as_view(), name="organization-list-create"),
+    path('organizations/', OrganizationListView.as_view(), name="organization-list-create"),
     path('organization-types/', OrganizationTypeListView.as_view(), name="organization-type-list"),
     path('organization-types/<int:pk>', OrganizationTypeRetrieveView.as_view(), name="organization-type-retrieve"),
 
     path('transmission-planning-regions/', TransmissionPlanningRegionListView.as_view(), name="transmission-planning-regions-list"),
     
-    path('customers/', CustomerCreateView.as_view(), name="customer-create"),
-    path('customer-request-relationships/', CustomerRequestRelationshipListCreateView.as_view(), name="customer-request-relationship-create"),
+    path('customers/<int:customer_id>', CustomerEditView.as_view(), name="customer-edit"),
+    path('customer-request-relationships/', CustomerRequestRelationshipListView.as_view(), name="customer-request-relationship-create"),
     
-    # path('cohorts/', CohortCreateView.as_view(), name="cohort-create"),
-    # path('cohorts/add-customer/', CohortAddCustomerView.as_view(), name="cohort-customer-add"),
+    path('cohorts/', CohortCreateView.as_view(), name="cohort-create"),
+    path('cohorts/add-customer/', CohortAddCustomerView.as_view(), name="cohort-customer-add"),
 
     path('topics/', TopicListView.as_view(), name="topic-list"),
     

--- a/backend/api/core/views/__init__.py
+++ b/backend/api/core/views/__init__.py
@@ -2,10 +2,10 @@ from .request import RequestListView, RequestDetailView, RequestMarkCompleteView
 from .depth import DepthListView, DepthRetrieveView
 from .state import StateListView, StateRetrieveView
 from .organization_type import OrganizationTypeListView, OrganizationTypeRetrieveView
-from .organization import OrganizationListCreateView
+from .organization import OrganizationListView
 from .transmission_planning_region import TransmissionPlanningRegionListView
-from .customer import CustomerCreateView
-from .customer_request_relationship import CustomerRequestRelationshipListCreateView
+from .customer import CustomerEditView
+from .customer_request_relationship import CustomerRequestRelationshipListView
 from .cohort import CohortCreateView, CohortAddCustomerView
 from .intake_form import ProcessIntakeForm
 from .identity import IdentityListView
@@ -33,10 +33,10 @@ __all__ = [
     "StateRetrieveView",
     "OrganizationTypeListView",
     "OrganizationTypeRetrieveView",
-    "OrganizationListCreateView",
+    "OrganizationListView",
     "TransmissionPlanningRegionListView",
-    "CustomerCreateView",
-    "CustomerRequestRelationshipListCreateView",
+    "CustomerEditView",
+    "CustomerRequestRelationshipListView",
     "CohortCreateView",
     "CohortAddCustomerView",
     "ProcessIntakeForm",

--- a/backend/api/core/views/cohort.py
+++ b/backend/api/core/views/cohort.py
@@ -1,19 +1,44 @@
+from rest_framework import generics, authentication, permissions
 from django.db import IntegrityError
 from rest_framework import generics, views, response, status
 
 from core.models import Cohort, Customer
 from core.serializers import CohortSerializer
+from core.permissions import IsAdmin, IsCoordinator, IsProgramLead
+
+from allauth.headless.contrib.rest_framework.authentication import (
+    XSessionTokenAuthentication,
+)
 
 class CohortCreateView(generics.CreateAPIView):
     queryset = Cohort.objects.all()
     serializer_class = CohortSerializer
 
+    authentication_classes = [
+        authentication.SessionAuthentication,
+        XSessionTokenAuthentication,
+    ]
 
-#TODO: MORE TESTS NEEDED!!!!!!!!
+    permission_classes = [
+        permissions.IsAuthenticated,
+        IsAdmin|IsCoordinator|IsProgramLead
+    ]
+
+
 class CohortAddCustomerView(views.APIView):
     """
     Add a Customer to a Cohort.
     """
+
+    authentication_classes = [
+        authentication.SessionAuthentication,
+        XSessionTokenAuthentication,
+    ]
+
+    permission_classes = [
+        permissions.IsAuthenticated,
+        IsAdmin|IsCoordinator|IsProgramLead
+    ]
         
     def post(self, request):
         if not request.data.get("cohort"):

--- a/backend/api/core/views/customer.py
+++ b/backend/api/core/views/customer.py
@@ -24,7 +24,7 @@ class CustomerEditView(views.APIView):
         IsAdmin|IsProgramLead|IsCoordinator|IsLabLead
     ]
     
-    def post(self, request, customer_id):
+    def patch(self, request, customer_id):
         try:
             customer_obj = Customer.objects.get(pk=customer_id)
         except Customer.DoesNotExist:

--- a/backend/api/core/views/customer.py
+++ b/backend/api/core/views/customer.py
@@ -21,7 +21,7 @@ class CustomerEditView(views.APIView):
 
     permission_classes = [
         permissions.IsAuthenticated,
-        # IsAdmin|IsProgramLead|IsCoordinator|IsLabLead
+        IsAdmin|IsProgramLead|IsCoordinator|IsLabLead
     ]
     
     def post(self, request, customer_id):
@@ -32,8 +32,8 @@ class CustomerEditView(views.APIView):
 
         # Making sure the customer that is being edited is associated with a request that is actionable for the user
         # i.e. preventing user from editing arbitrary customers in system 
-        # if not CustomerRequestRelationship.objects.filter(customer=customer_obj).filter(request__in=BaseUserAwareRequest(request=request).get_actionable()):
-        #     return Response(data={"message": "Insufficient authorization to edit given customer's information"}, status=status.HTTP_400_BAD_REQUEST)
+        if not CustomerRequestRelationship.objects.filter(customer=customer_obj).filter(request__in=BaseUserAwareRequest(request=request).get_actionable()):
+            return Response(data={"message": "Insufficient authorization to edit given customer's information"}, status=status.HTTP_400_BAD_REQUEST)
 
         customer_patch_data = dict() 
         

--- a/backend/api/core/views/customer.py
+++ b/backend/api/core/views/customer.py
@@ -1,8 +1,85 @@
-from rest_framework import generics
+from rest_framework import views, authentication, permissions, status
+from rest_framework.response import Response
 
-from core.models import Customer
-from core.serializers import CustomerSerializer
+from core.views.request import BaseUserAwareRequest
+from core.models import * 
+from core.serializers import CustomerSerializer, CustomerEditSerializer
+from core.permissions import *
 
-class CustomerCreateView(generics.CreateAPIView):
+from allauth.headless.contrib.rest_framework.authentication import (
+    XSessionTokenAuthentication,
+)
+
+class CustomerEditView(views.APIView):
     queryset = Customer.objects.all()
     serializer_class = CustomerSerializer
+
+    authentication_classes = [
+        authentication.SessionAuthentication,
+        XSessionTokenAuthentication,
+    ]
+
+    permission_classes = [
+        permissions.IsAuthenticated,
+        # IsAdmin|IsProgramLead|IsCoordinator|IsLabLead
+    ]
+    
+    def post(self, request, customer_id):
+        try:
+            customer_obj = Customer.objects.get(pk=customer_id)
+        except Customer.DoesNotExist:
+            return Response(data={"message":"Customer with given ID does not exist"})
+
+        # Making sure the customer that is being edited is associated with a request that is actionable for the user
+        # i.e. preventing user from editing arbitrary customers in system 
+        # if not CustomerRequestRelationship.objects.filter(customer=customer_obj).filter(request__in=BaseUserAwareRequest(request=request).get_actionable()):
+        #     return Response(data={"message": "Insufficient authorization to edit given customer's information"}, status=status.HTTP_400_BAD_REQUEST)
+
+        customer_patch_data = dict() 
+        
+        if not request.data:
+            return Response(data={"message": "Missing request body"}, status=status.HTTP_204_NO_CONTENT)
+        
+        if "name" in request.data and (request.data.get("name") is not None):
+            customer_patch_data["name"] = request.data.get("name")
+        
+        if "email" in request.data and (request.data.get("email") is not None):
+            customer_patch_data["email"] = request.data.get("email")
+
+        if "phone" in request.data and (request.data.get("phone") is not None):
+            customer_patch_data["phone"] = request.data.get("phone")
+
+        if "title" in request.data and (request.data.get("title") is not None):
+            customer_patch_data["title"] = request.data.get("title")
+
+        if "tpr" in request.data and (request.data.get("tpr") is not None):
+            try:
+                TransmissionPlanningRegion.objects.get(pk=request.data.get("tpr")) 
+            except TransmissionPlanningRegion.DoesNotExist:
+                return Response(data={"message":"Transmission planning region with given ID does not exist"})
+
+            customer_patch_data["tpr"] = request.data.get("tpr")
+
+        if "state" in request.data and (request.data.get("state") is not None):
+            try:
+                State.objects.get(pk=request.data.get("state")) 
+            except State.DoesNotExist:
+                return Response(data={"message":"State with given ID does not exist"})
+
+            customer_patch_data["state"] = request.data.get("state")
+
+        if "org" in request.data and (request.data.get("org") is not None):
+            try:
+                Organization.objects.get(pk=request.data.get("org")) 
+            except Organization.DoesNotExist:
+                return Response(data={"message":"Organization with given ID does not exist"})
+            customer_patch_data["org"] = request.data.get("org")
+        
+        serializer = CustomerEditSerializer(customer_obj, data=customer_patch_data, partial=True)
+        if serializer.is_valid():
+            serializer.save()
+        else:
+            return Response(data=serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+            
+
+        return Response(data=CustomerSerializer(Customer.objects.get(pk=customer_id)).data,status=status.HTTP_200_OK)

--- a/backend/api/core/views/customer_request_relationship.py
+++ b/backend/api/core/views/customer_request_relationship.py
@@ -8,7 +8,7 @@ from allauth.headless.contrib.rest_framework.authentication import (
     XSessionTokenAuthentication,
 )
 
-class CustomerRequestRelationshipListCreateView(generics.ListCreateAPIView):
+class CustomerRequestRelationshipListView(generics.ListAPIView):
     queryset = CustomerRequestRelationship.objects.all()
     serializer_class = CustomerRequestRelationshipSerializer
 

--- a/backend/api/core/views/organization.py
+++ b/backend/api/core/views/organization.py
@@ -3,6 +3,6 @@ from rest_framework import generics
 from core.models import Organization
 from core.serializers import OrganizationSerializer
 
-class OrganizationListCreateView(generics.ListCreateAPIView):
+class OrganizationListView(generics.ListAPIView):
     queryset = Organization.objects.select_related("type")
     serializer_class = OrganizationSerializer


### PR DESCRIPTION
Fixes #114 
Add endpoint for editing customer info

context aware PATCH request to BACKEND/customers/(customer_id)/
Expected request body:
```
{
    "org"(optional): (id that is not empty and not null),
    "state"(optional): (id that is not empty and not null),
    "tpr"(optional): (id that is not empty and not null),
    "email"(optional): (string that is not empty and not null),
    "name"(optional): (string that is not empty and not null),
    "phone"(optional): (string that is not empty and not null),
    "title"(optional): (string that is not empty and not null),
}
```

Successful response will include customer with new info changed