### PR TITLE
Add audit triggers and audit UI

### DIFF
--- a/backend/api/core/models/audit_history.py
+++ b/backend/api/core/models/audit_history.py
@@ -4,11 +4,14 @@ from core.models import *
 
 # Example audit history actions
 class ActionType(models.TextChoices):
-    Assignment="Assignment"
-    AddAttachment="Add Attachment"
-    RemoveAttachment="Remove Attachment"
-    EditRequestInfo="Edit Request Information"
-    EditCustomerInfo="Edit Customer Information"
+    Assignment="Assignment change"
+    AddAttachment="Add attachment"
+    RemoveAttachment="Remove attachment"
+    AddNote="Add note"
+    RemoveNote="Remove note"
+    EditRequestDetails="Edit request details"
+    EditCustomerDetails="Edit customer details"
+    StatusChange="Status change"
 
 
 class AuditHistory(models.Model):

--- a/backend/api/core/utils.py
+++ b/backend/api/core/utils.py
@@ -1,0 +1,30 @@
+import json
+
+from core.models.audit_history import AuditHistory
+from core.models.role import Role
+
+
+def create_audit_history(request, request_obj, action_type, description):
+    """
+    Create an audit history entry for a given action on a request.
+    """
+    try:
+        # Get role from request context
+        maybe_context = request.headers.get("Context")
+        if maybe_context:
+            context = json.loads(maybe_context)
+            role_id = context.get("role")
+            if role_id:
+                role = Role.objects.get(pk=role_id)
+                
+                # Create the audit history entry
+                AuditHistory.objects.create(
+                    request=request_obj,
+                    user=request.user,
+                    role=role,
+                    action_type=action_type,
+                    description=description
+                )
+    except (json.JSONDecodeError, Role.DoesNotExist) as e:
+        print(f"Error creating audit history: {e}")
+        pass

--- a/backend/api/core/views/assignment.py
+++ b/backend/api/core/views/assignment.py
@@ -6,11 +6,13 @@ from allauth.headless.contrib.rest_framework.authentication import (
     XSessionTokenAuthentication,
 )
 
+from core.utils import create_audit_history
 from core.util.notifications import send_email_notification
 from core.util.email_prompts import generic_template
 from core.permissions import IsAdmin, IsLabLead
 from core.views.owner import OwnerListView
 from core.models import *
+from core.models.audit_history import ActionType
 from core.constants import DOMAINTYPE, ROLE
 
 class AssignmentView(views.APIView):
@@ -111,6 +113,7 @@ class AssignmentView(views.APIView):
                 with transaction.atomic():
                     ta_request.save()
                     ta_request.receipt.save()
+                    create_audit_history(request, ta_request, ActionType.Assignment, f"Assigned to {str(new_owner)}")
 
             except Exception as e:
                 return Response(data={"message": f"{e}"}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
@@ -144,6 +147,7 @@ class AssignmentView(views.APIView):
                 with transaction.atomic():
                     ta_request.receipt.save()
                     ta_request.save()
+                    create_audit_history(request, ta_request, ActionType.Assignment, f"Assigned to {str(expert.email)} as expert")
             except:
                 return Response(data={"message": f"{e}"}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
         

--- a/backend/api/core/views/note.py
+++ b/backend/api/core/views/note.py
@@ -1,6 +1,8 @@
 from rest_framework import views, authentication, permissions, status
 from rest_framework.response import Response
 
+from core.models.audit_history import ActionType
+from core.utils import create_audit_history
 from core.permissions import IsAdmin
 from core.models import Note, Request
 from core.serializers import NoteSerializer, NoteCreateSerializer
@@ -80,6 +82,7 @@ class NoteCreateView(views.APIView):
             return Response(data=serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
         response_note = serializer.save()
+        create_audit_history(request, request_obj, ActionType.AddNote, f"Added note: {response_note.content[:10]}...")
 
         return Response(data=(NoteSerializer(response_note)).data, status=status.HTTP_200_OK)
 
@@ -109,5 +112,6 @@ class NoteDeleteView(views.APIView):
             return Response(data={"message":"Note with given ID does not exist"}, status=status.HTTP_400_BAD_REQUEST)
 
         note_obj.delete()
+        create_audit_history(request, note_obj.request, ActionType.RemoveNote, f"Removed note: {note_obj.content[:10]}...")
 
         return Response(data={"message": "Note deleted successfully"}, status=status.HTTP_204_NO_CONTENT)

--- a/frontend/src/api/dashboard/types.ts
+++ b/frontend/src/api/dashboard/types.ts
@@ -42,6 +42,14 @@ export interface TATopic {
   description: string;
 }
 
+export interface TAAuditHistoryItem {
+  action_type: string;
+  date: string;
+  description: string;
+  role: string;
+  user: string;
+}
+
 export interface TANote {
   id: number;
   content: string;
@@ -123,6 +131,7 @@ export interface TARequestDetail {
   actual_completion_date: string | null;
   topics: TATopic[];
   attachments: TAAttachment[];
+  audit_history: TAAuditHistoryItem[];
 }
 
 export interface TARequestDetailMutation {

--- a/frontend/src/features/requests/RequestAuditHistory.tsx
+++ b/frontend/src/features/requests/RequestAuditHistory.tsx
@@ -1,0 +1,34 @@
+import { DataGrid } from '@mui/x-data-grid';
+import { TAAuditHistoryItem } from '../../api/dashboard/types';
+import { formatDatetime } from '../../utils/utils';
+
+interface RequestAuditHistoryProps {
+  auditHistoryItems?: TAAuditHistoryItem[] | null;
+}
+
+export const RequestAuditHistory: React.FC<RequestAuditHistoryProps> = ({ auditHistoryItems }) => {
+  return (
+    <DataGrid
+      rows={auditHistoryItems || []}
+      columns={[
+        { field: 'action_type', headerName: 'Action', flex: 1, minWidth: 150 },
+        {
+          field: 'date',
+          headerName: 'Date',
+          flex: 1,
+          minWidth: 200,
+          valueFormatter: (value) => formatDatetime(value),
+        },
+        { field: 'user', headerName: 'User', flex: 1, minWidth: 150 },
+        { field: 'role', headerName: 'Role', flex: 1, minWidth: 150 },
+        { field: 'description', headerName: 'Description', flex: 2, minWidth: 300 },
+      ]}
+      getRowId={(row) => `${row.date}-${row.user}-${row.action_type}`}
+      pageSizeOptions={[5, 10, 25]}
+      initialState={{
+        pagination: { paginationModel: { pageSize: 5 } },
+      }}
+      sx={{ backgroundColor: 'white' }}
+    />
+  );
+};

--- a/frontend/src/routes/_private/dashboard/requests/$requestId.tsx
+++ b/frontend/src/routes/_private/dashboard/requests/$requestId.tsx
@@ -22,6 +22,7 @@ import {
 } from '../../../../utils/queryOptions';
 import { RequestAttachments } from '../../../../features/requests/RequestAttachments';
 import { RequestNotes } from '../../../../features/requests/RequestNotes';
+import { RequestAuditHistory } from '../../../../features/requests/RequestAuditHistory';
 
 export const Route = createFileRoute('/_private/dashboard/requests/$requestId')({
   loader: async ({ context, params }) => {
@@ -49,6 +50,7 @@ function SelectedRequest() {
   const { data: selectedRequest } = useSuspenseQuery(
     requestDetailQueryOptions(params.requestId, identity)
   );
+  console.log(selectedRequest);
   const { data: selectedRequestNotes } = useSuspenseQuery(
     notesQueryOptions(params.requestId, identity)
   );
@@ -194,7 +196,7 @@ function SelectedRequest() {
                 />
               </TabPanel>
               <TabPanel value={tabValue} index="audit-history">
-                Audit history
+                <RequestAuditHistory auditHistoryItems={selectedRequest.audit_history} />
               </TabPanel>
             </InfoPanel>
           </Stack>


### PR DESCRIPTION
Resolves #12
Resolves #27 

Finishes the audit history backend by introducing triggers that populate the audit history table when actions are taken on requests. Also includes a table in the UI to display audit history items for each request.